### PR TITLE
feat: Adds custom install routine for the ilp kit

### DIFF
--- a/src/lib/dependency-manager.js
+++ b/src/lib/dependency-manager.js
@@ -114,6 +114,14 @@ class DependencyManager {
       dependencyOverrides[dependency] = repo + '#' + branch
     }
 
+    // Check if ilp kit has to be installed
+    const ilpKitRepo = this.defaultDependencies['ilp-kit']
+    const ilpKitBranch = dependencyOverrides['ilp-kit']
+      ? dependencyOverrides['ilp-kit'].split('#')[1] : 'master'
+    // We install the ilp kit manually, remove from dependencies to avoid installing twice
+    this.defaultDependencies['ilp-kit'] && delete this.defaultDependencies['ilp-kit']
+    dependencyOverrides['ilp-kit'] && delete dependencyOverrides['ilp-kit']
+
     // Create package.json
     const dummyPackageJSONPath = path.resolve(this.testDir, 'package.json')
     const dummyPackageJSON = this.generateDummyPackageJSON(dependencyOverrides)
@@ -122,6 +130,37 @@ class DependencyManager {
     // Install dependencies
     console.log('Installing dependencies:')
     yield spawn('npm', ['install'], {stdio: 'inherit'})
+
+    // Check if ilp kit has to be installed
+    if (ilpKitRepo) {
+      yield this.installIlpKit(ilpKitRepo, ilpKitBranch)
+    }
+  }
+
+  // This function installs the ilp kit by cloning it from github and linking it
+  // against the integration tests. This is done to avoid a problem if the ilp kit
+  // is installed by the DependencyManager via the dummy package.json.
+  //
+  // The ilp kit cannot be installed via the dummy package.json as the
+  // other dependencies, because it seems babel transpilation does not work in this case.
+  // The error message is:
+  // > Error: Options {"loose":true} passed to .../node_modules/babel-preset-es2015/lib/index.js
+  // > which does not accept options.
+  // > (While processing preset: ".../node_modules/babel-preset-es2015/lib/index.js")
+  // > (While processing preset: ".../node_modules/babel-preset-es2015/lib/index.js")
+  // > (While processing preset: ".../node_modules/babel-preset-react/lib/index.js")
+  // ...
+  * installIlpKit (repo, branch) {
+    console.log('Installing ILP kit:')
+    const repoUrl = 'https://github.com/' + repo
+    const targetDir = path.join(this.testDir + '/ilp-kit')
+    yield spawn('git', ['clone', repoUrl, '-b', branch, targetDir], {stdio: 'inherit'})
+
+    process.chdir(targetDir)
+    yield spawn('npm', ['install'], {stdio: 'inherit'})
+    yield spawn('npm', ['link'], {stdio: 'inherit'})
+    process.chdir(this.testDir)
+    yield spawn('npm', ['link', 'ilp-kit'], {stdio: 'inherit'})
   }
 }
 


### PR DESCRIPTION
The ilp kit cannot be installed via the dummy package.json as the other dependencies (it seems babel transpilation does not work if the ilp kit is installed as a dependency). Therefore, we install the ilp kit separately and "npm link" it.