### PR TITLE
Disallow breaking ilp-kit

### DIFF
--- a/src/lib/dependency-manager.js
+++ b/src/lib/dependency-manager.js
@@ -164,6 +164,7 @@ class DependencyManager {
     yield spawn('git', ['clone', repoUrl, '-b', branch, targetDir], {stdio: 'inherit'})
 
     process.chdir(targetDir)
+    yield spawn('ln', ['-s', '../node_modules', '.'], {stdio: 'inherit'})
     yield spawn('npm', ['install'], {stdio: 'inherit'})
     yield spawn('npm', ['link'], {stdio: 'inherit'})
     process.chdir(this.testDir)


### PR DESCRIPTION
By using all the master branches of components when testing ilp-kit,
we make sure a change in one of the components is immediately used by
ilp-kit.

When making a breaking change in for instance `ilp-connector`,
create a branch on the ilp-kit repo, with the same branch name, that
pulls in your change, and then it's up to you (with help from your team
mates, where necessary) to change the ilp-kit code until the integration
tests pass with your change.

Previously, when making a breaking change in one component, the
integration tests would require the author to update all other components
except ilp-kit. This would create technological debt and cause ilp-kit
to be running older versions of all components, meaning we're not really
using, nor testing, our inventions, and the RFCs would not describe the
live situation on the public interledger. This PR aims to end that.

See https://circleci.com/gh/interledgerjs/ilp-plugin-virtual to see it in action.